### PR TITLE
Remove broken link to roadmap doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ We will add you to the list if you make any meaningful contribution!
 
 This project is maintained by [Segment](https://segment.com/)
 
-Please take a look at the [contributing guide](.github/CONTRIBUTING.md) and [roadmap](ROADMAP.md) to better understand what to work on.
+Please take a look at the [contributing guide](.github/CONTRIBUTING.md) to better understand what to work on.
 
 ## 👏 Respect earns Respect
 


### PR DESCRIPTION
It was deleted in a commit for v4.0: https://github.com/cdtinney/evergreen/commit/aca37cb21dbc0f95c90b69f6b4217c0f0c3916f6

Resolves #357
